### PR TITLE
prevent line from jumping too far away

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -39,7 +39,8 @@
       showerror('you are outside');
     } else {
       cx.beginPath();
-      if (oldx > 0 && oldy > 0) {
+      if ((oldx > 0 && oldy > 0) &&
+          (Math.abs(oldx - x) < cx.lineWidth / 2 && Math.abs(oldy - y) < cx.lineWidth / 2)) {
         cx.moveTo(oldx, oldy);
       }
       cx.lineTo(x, y);


### PR DESCRIPTION
Hi, 

just adding a little improvement to prevent not intuitive jumps.

Example:
if you start to draw the line in the upper left region of letter Y and drag it to middle (down/right) and than want to start in the upper right region, line will be automatically filled whenever you start dragging from there. 

To prevent this kind of behavior I just added another if statement to the `compare.js` file, which was not shown in videos.
